### PR TITLE
mplot1 and mplot3 updates

### DIFF
--- a/examples/mplot1.py
+++ b/examples/mplot1.py
@@ -18,11 +18,11 @@ def d(ff,box=[]):
         return h[0].header, h[0].data[box[1]:box[3], box[0]:box[2]]
 
 
-def dsum(i0,i1, box=[]):
+def dsum(i0,i1,step = 1, box=[]):
     """ for a range of fits files
         compute the mean and dispersion from the mean
     """
-    for i in range(i0,i1+1):
+    for i in range(i0,i1+1,step):
         ff = 'IMG%05d.FIT' % i
         h1, d1 = d(ff,box)
         if i == i0: 
@@ -74,18 +74,25 @@ if __name__ == '__main__':
     #--end, -e n
     #--box x1 y1 x2 y2
     parser = ap.ArgumentParser(description='Plotting .fits files.')
-    parser.add_argument('-f', '--frame', nargs = 2, required = True, type = int, help = 'Starting and ending parameters for the frames analyzed')
+    parser.add_argument('-f', '--frame', nargs = '*', required = True, type = int, help = 'Starting and ending parameters for the frames analyzed')
     parser.add_argument('-b', '--box', nargs = 4, type = int, help = 'Coordinates for the bottom left corner and top right corner of a rectangle of pixels to be analyzed from the data. In the structure x1, y1, x2, y2 (1 based numbers)')
     args = vars(parser.parse_args())
 
-    start = args['frame'][0]           # starting frame (IMGnnnnn.FIT)
-    end   = args['frame'][1]           # ending frame
+    if len(args['frame']) >= 2:
+        start = args['frame'][0]           # starting frame (IMGnnnnn.FIT)
+        end   = args['frame'][1]           # ending frame
+        if len(args['frame']) == 3:
+            step = args['frame']
+        else:
+            step = 1
+    else:
+        raise Exception,"-f needs at least 2 arguments"
     box   = args['box']                # BLC and TRC
     if box == None:
         box = []
 
     # compute the average and dispersion of the series        
-    h1,sum1,sum2,cube = dsum(start,end,box)           # end can be uninitialized here might throw an error?
+    h1,sum1,sum2,cube = dsum(start,end,step,box=box)           # end can be uninitialized here might throw an error?
     nz = cube.shape[0]
     
     # delta X and Y images

--- a/examples/mplot2.py
+++ b/examples/mplot2.py
@@ -22,7 +22,7 @@ if __name__ == '__main__':
         box = []
 
     # compute the average and dispersion of the series        
-    h1,sum1,sum2,cube = mp.dsum(start,end,box)           # end can be uninitialized here might throw an error?
+    h1,sum1,sum2,cube = mp.dsum(start,end,box = box)           # end can be uninitialized here might throw an error?
     n = 5
     msum = filters.median_filter(sum1, size = (n,n))
     rmsum = (sum1 - msum) / msum

--- a/examples/mplot3.py
+++ b/examples/mplot3.py
@@ -5,19 +5,55 @@ import mplot1 as mp
 #Takes a 3D numpy array and takes a slice of it on the given axis with a given value
 #*Errors are not handled in this script*
 
-def splice(args):
-    cube = fits.open('cube.fits')
-    data = cube[0].data
-    header = cube[0].header
-    if args['x'] != None:
-        splice = data[:,:,args['x']]
-    elif args['y'] != None:
-        splice = data[:,args['y'],:]
+#slices the given data. NOTE: the header must have NAXIS = 3. Maybe change this later? option for NAXIS 2 or 3?
+def cslice(header, data, flag, value):
+    h = header.copy()
+    h.pop('NAXIS3')
+    h['NAXIS'] = 2
+    nx = data.shape[2]
+    ny = data.shape[1]
+    nz = data.shape[0]
+    if flag == 'x':
+        d = data[:,:,args['x'][0]]
+        h['NAXIS1'] = ny
+        h['NAXIS2'] = nz
+    elif flag == 'y':
+        d = data[:,args['y'][0],:]
+        h['NAXIS1'] = nx
+        h['NAXIS2'] = nz
     else:
-        splice = data[args['z'],:,:]
-    #using squeeze because data[:,:,int] is returning a 3D array for some reason. squeeze() gets rid of the length 1 side
-    splice = splice.squeeze()
-    return splice, header
+        d = data[args['z'][0],:,:]
+        h['NAXIS1'] = nx
+        h['NAXIS2'] = ny
+    #returns data and a header
+    return d, h
+    
+#calls the function cslice() with proper parameters based on the given arguments
+#returns a list of tuples containing a tuple of data and header and a filename
+#so sliceList[0] = ((data, header), filename)
+#   sliceList[0][0] = (data, header)
+#   sliceList[0][0][0] = data and sliceList[0][0][1] = header
+#seems crazy, but works fine in the for loop
+def sliceHandler(args):
+    
+    #Open the cube and extract the data and header from it
+    c = fits.open('cube.fits')
+    d = c[0].data
+    h = c[0].header
+
+    #list to hold each slice
+    sliceList = []
+    #if an argument was used, then take a slice of it and add that slice to the lists
+    if args['x'] != None:
+        s = (cslice(h, d, 'x', args['x'][0]), 'slice_x.fits')
+        sliceList.append(s)
+    if args['y'] != None:
+        s = (cslice(h, d, 'y', args['y'][0]), 'slice_y.fits')
+        sliceList.append(s)
+    if args['z'] != None:
+        s = (cslice(h, d, 'z', args['z'][0]), 'slice_z.fits')
+        sliceList.append(s)
+    return sliceList
     
 if __name__ == '__main__':
     
@@ -27,12 +63,12 @@ if __name__ == '__main__':
     parser.add_argument('-z',nargs = 1, type = int, required = False, help = 'Value for z as sliced axis')
     args = vars(parser.parse_args())
     
-    data, header = splice(args)
     
-    #It's a 2D array now
-    header.pop('NAXIS3')
-    header['NAXIS'] = 2
+    sliceList = sliceHandler(args)
 
-    #Show the image and save it
-    mp.show(data)
-    fits.writeto('splice.fits', data, header, clobber=True)
+    #Show each image and save it
+    for s in sliceList:
+        data = s[0][0]
+        header = s[0][1]
+        mp.show(data)
+        fits.writeto(s[1], data, header, clobber=True)


### PR DESCRIPTION
Changed mplot1 to now have the optional argument for step size for -f flag. so -f fb fe fs. mplot3 can how take multiple flags so mplot3.py -x 400 -y 450 will show and save two images named slice_x.fits and slice_y.fits respectively. The function that slices the cube cslice() takes a header, data, a flag string, and a flag value and will slice it and return data and a header so it can be used stand-alone from the rest of the script. 