### PR TITLE
Removed default date

### DIFF
--- a/www/js/archives.js
+++ b/www/js/archives.js
@@ -219,7 +219,6 @@ function drawCalendar() {
     new Pikaday({ 
         field: document.getElementById('datepicker'),
         format: 'ddd MMM DD YYYY',
-        defaultDate: moment(`2018-11-20`).toDate(),
         onSelect: renderDate,
         onDraw: async function(evt) {
             let { year, month } = evt.calendars[0];


### PR DESCRIPTION
Did not make sense to have a default date in 2018. I believe removing this allows the default date to just be the current date, I am not 100% if this works, not familiar with js.